### PR TITLE
Include requirements.txt, LICENSE.txt, and README.md in source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ include jupyter_dash/nbextension *.js
 include jupyter_dash/labextension/package.json
 include jupyter_dash/labextension/dist *.tgz
 include requirements.txt
+include requirements-dev.txt
 include README.md
 include LICENSE.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,6 @@ include jupyter_dash/nbextension *.json
 include jupyter_dash/nbextension *.js
 include jupyter_dash/labextension/package.json
 include jupyter_dash/labextension/dist *.tgz
+include requirements.txt
+include README.md
+include LICENSE.txt

--- a/jupyter_dash/version.py
+++ b/jupyter_dash/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.1"
+__version__ = "0.2.1.post1"


### PR DESCRIPTION
Addresses https://github.com/plotly/jupyter-dash/issues/11. The missing requirements.txt file causes an error when building the package from the source distribution.