### PR TITLE
Config edit fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,16 @@
 /build/
 .ipynb_checkpoints
 /extensions/jupyterlab/README.md
+__pycache__/
+*.py[cod]
+*$py.class
+.mypy_cache/
+.DS_Store
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+vv

--- a/jupyter_dash/jupyter_app.py
+++ b/jupyter_dash/jupyter_app.py
@@ -228,7 +228,10 @@ class JupyterDash(dash.Dash):
             requests_pathname_prefix = requests_pathname_prefix.format(port=port)
         else:
             requests_pathname_prefix = '/'
-        self.config.update({'requests_pathname_prefix': requests_pathname_prefix})
+        # low-level setter to circumvent Dash's config locking
+        # normally it's unsafe to alter requests_pathname_prefix this late, but
+        # Jupyter needs some unusual behavior.
+        dict.__setitem__(self.config, "requests_pathname_prefix", requests_pathname_prefix)
 
         # Compute server_url url
         if self.server_url is None:


### PR DESCRIPTION
Fixes #75 - Dash 2.1 closed a loophole with editing the dash app config dict