### PR TITLE
preemptively import orjson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Fixed
   - Fixed `werkzeug` 2.1.0 import and `skip` calculation, shutdown deprecation warning.
+  - Work around a partial import of `orjson` when it's installed and you use `mode="jupyterlab"`
 
 ## 0.4.1 - 2022-02-16
 ### Fixed

--- a/jupyter_dash/jupyter_app.py
+++ b/jupyter_dash/jupyter_app.py
@@ -287,6 +287,14 @@ class JupyterDash(dash.Dash):
             inline_exceptions=inline_exceptions,
         )
 
+        # prevent partial import of orjson when it's installed and mode=jupyterlab
+        # TODO: why do we need this? Why only in this mode? Importing here in
+        # all modes anyway, in case there's a way it can pop up in another mode
+        try:
+            import orjson
+        except ImportError:
+            pass
+
         @retry(
             stop_max_attempt_number=15,
             wait_exponential_multiplier=100,


### PR DESCRIPTION
Without this, in mode="jupyterlab" we see (sometimes) when the page index tries to load:
```
  AttributeError: partially initialized module 'orjson' has no attribute
  'OPT_SORT_KEYS' (most likely due to a circular import)
```

I don't like this, I feel like we're papering over a deeper problem that may still manifest in another way, but this is the best I can do now and we really need to make a release soon...

cc @T4rk1n 