### PR TITLE
Propagate start errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to `jupyter-dash` will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
+### Fixed
+- Propagate start error message. [#94](https://github.com/plotly/jupyter-dash/pull/94)
+
 ### Added
 
 - Support for `Dash.run` method added in Dash 2.4.0

--- a/jupyter_dash/_stoppable_thread.py
+++ b/jupyter_dash/_stoppable_thread.py
@@ -12,11 +12,12 @@ class StoppableThread(threading.Thread):
 
     def kill(self):
         thread_id = self.get_id()
-        res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
-            ctypes.c_long(thread_id), ctypes.py_object(SystemExit)
-        )
-        if res == 0:
-            raise ValueError(f"Invalid thread id: {thread_id}")
-        if res > 1:
-            ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(thread_id), None)
-            raise SystemExit("Stopping thread failure")
+        if thread_id:
+            res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
+                ctypes.c_long(thread_id), ctypes.py_object(SystemExit)
+            )
+            if res == 0:
+                raise ValueError(f"Invalid thread id: {thread_id}")
+            if res > 1:
+                ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(thread_id), None)
+                raise SystemExit("Stopping thread failure")


### PR DESCRIPTION
Propagate start errors instead of the same `Address already in use` error messages when starting the threaded server.